### PR TITLE
Follow naming conventions in id

### DIFF
--- a/terminologies/phenotype/wild_type.jsonld
+++ b/terminologies/phenotype/wild_type.jsonld
@@ -1,5 +1,5 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/phenotype/wild_type",
+  "@id": "https://openminds.ebrains.eu/controlledTerms/phenotype/wildType",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Phenotype",
   "name": "wild type",
   "definition": null,

--- a/terminologies/phenotype/wild_type.jsonld
+++ b/terminologies/phenotype/wild_type.jsonld
@@ -1,7 +1,7 @@
 {
-  "@id": "https://openminds.ebrains.eu/controlledTerms/phenotype/wildType",
+  "@id": "https://openminds.ebrains.eu/controlledTerms/phenotype/wildtype",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Phenotype",
-  "name": "wild type",
+  "name": "wildtype",
   "definition": null,
   "description": null,
   "ontologyIdentifier": null


### PR DESCRIPTION
Renaming wild_type to wildType for the id to follow the naming conventions -> fix for #15 