### PR TITLE
Restructuring of termSuggestion schema

### DIFF
--- a/schemas/termSuggestion.schema.tpl.json
+++ b/schemas/termSuggestion.schema.tpl.json
@@ -4,15 +4,16 @@
   "_categories": [
     "studyTarget"
   ],
-  "required": [
-    "terminology"
-  ],
   "properties": {
-    "terminology": {
-      "_instruction": "Add the terminology in which the suggested term should be integrated in.",
+    "addExistingTerminology": {
+      "_instruction": "Add an existing terminology in which the suggested term should be integrated in.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/controlledTerms/Terminology"
       ]
+    },
+    "suggestNewTerminology": {
+      "type": "string",
+      "_instruction": "Propose a name for a new terminology in which the suggested term should be integrated in."
     }
   }
 }


### PR DESCRIPTION
Instead of having only the required property "terminology", we restructured it so that one can choose to either "AddExistingTerminology" or to "suggestTerminology" when there none of the existing terminologies fit the suggested term. 

NOTE for curation: Both fields are optional, and the termSuggestion properties are all optional too (except for the "name" of the new term). Best practice will still be to fill in as much as possible ;) 

@olinux: FYI 

