### PR TITLE
Adding stimulus related controlled terms

### DIFF
--- a/schemas/stimulusModality.schema.tpl.json
+++ b/schemas/stimulusModality.schema.tpl.json
@@ -1,0 +1,4 @@
+{
+    "_type": "https://openminds.ebrains.eu/controlledTerms/StimulusModality",
+    "_extends": "controlledTerm.schema.tpl.json"
+}

--- a/schemas/stimulusType.schema.tpl.json
+++ b/schemas/stimulusType.schema.tpl.json
@@ -1,0 +1,4 @@
+{
+    "_type": "https://openminds.ebrains.eu/controlledTerms/StimulusType",
+    "_extends": "controlledTerm.schema.tpl.json"
+}


### PR DESCRIPTION
The stimulus defined in the [openMINDS/ephys/Stimulus](https://github.com/HumanBrainProject/openMINDS_ephys) have two controlled terms, `StimulusModality` and  `StimulusType`.
These two controlled terms are needed in order to improve the province and findability of the `ephys/Stimulus` and `ephys/StimulationExperiment`.