### PR TITLE
Adding device type

### DIFF
--- a/schemas/deviceType.schema.tpl.json
+++ b/schemas/deviceType.schema.tpl.json
@@ -1,0 +1,4 @@
+{
+    "_type": "https://openminds.ebrains.eu/controlledTerms/DeviceType",
+    "_extends": "controlledTerm.schema.tpl.json"
+}


### PR DESCRIPTION
We need to enforce control on the device type that are used in the `Device` object of the [openMINDS/ephys](https://github.com/HumanBrainProject/openMINDS_ephys). So to this end I propose we add `DeviceType` to controlledTerms. 
This term is useful for future extensions too as we would need it in fMRI extension too. 