### PR TITLE
age category update

### DIFF
--- a/instances/ageCategory/primeAdult.jsonld
+++ b/instances/ageCategory/primeAdult.jsonld
@@ -4,7 +4,7 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/ageCategory/primeAdult",
   "@type": "https://openminds.ebrains.eu/controlledTerms/AgeCategory",
-  "definition": "'Prime adult' categorizes the life cycle stage of an animal or human that starts with completion of development and sexual maturity and ends before senescence.",
+  "definition": "'Prime adult' categorizes the life cycle stage of an animal or human that starts at the onset of sexual maturity or the cessation of growth, whichever comes last, and ends before senescence.",
   "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0733125",
   "knowledgeSpaceLink": null,

--- a/instances/ageCategory/youngAdult.jsonld
+++ b/instances/ageCategory/youngAdult.jsonld
@@ -4,7 +4,7 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/ageCategory/youngAdult",
   "@type": "https://openminds.ebrains.eu/controlledTerms/AgeCategory",
-  "definition": "'Young adult' categorizes the early stage of a prime adult when sexual maturity has been reached, but not the cessation of growth.",
+  "definition": "'Young adult' categorizes the early adult stage of an animal or human when sexual maturity has been reached, but not the cessation of growth.",
   "description": null,
   "interlexIdentifier": null,
   "knowledgeSpaceLink": null,

--- a/instances/ageCategory/youngAdult.jsonld
+++ b/instances/ageCategory/youngAdult.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/ageCategory/youngAdult",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/AgeCategory",
+  "definition": "'Young adult' categorizes the early stage of a prime adult when sexual maturity has been reached, but not the cessation of growth.",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "young adult",
+  "preferredOntologyIdentifier": null,
+  "synonym": [
+    "young adult stage",
+    "adolescent stage", 
+    "teenage"
+  ]
+}


### PR DESCRIPTION
related to #57 

Stage order: juvenile --> (young adult -->) prime adult --> late adult. 
Young adult is included in prime adult, but specifies that sexual maturity has been reached without the development of the organism to be completed. Prime adult starts at sexual maturity or end of growth (whichever comes first) and ends at senescence.    

**NOTE: Post-juvenile adult will be removed** but remains for now until the EBRAINS team has remapped the categories for their specimen. 
FYI @olinux 