### PR TITLE
changes for keywords

### DIFF
--- a/schemas/controlledTerm.schema.tpl.json
+++ b/schemas/controlledTerm.schema.tpl.json
@@ -1,4 +1,7 @@
 {
+  "_categories": [
+    "keyword"
+  ],
   "required": [
     "name"
   ],


### PR DESCRIPTION
As discussed some time ago, we want to increase the data integration within the openMINDS metadata models by changing the property keyword values of research product versions from string to any controlled term (incl. term suggestion for user-defined entries).

Actions for this to work:
1) introduce a keyword category to facilitate referencing to all controlled terms (@olinux please double check that _categories is merged (not replaced) when schemas are extended) [this PR]
2) changing the keyword property value from string to be a _linkedCategory = keyword for research product versions [PR on openMINDS core, coming soon]
3) (EBRAINS migration): replace all string keywords to be a term suggestion (is prepared already offline)