### PR TITLE
Disease model correction

### DIFF
--- a/instances/diseaseModel/alzheimersDiseaseModel.jsonld
+++ b/instances/diseaseModel/alzheimersDiseaseModel.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.ebrains.eu/vocab/"
   },
-  "@id": "https://openminds.ebrains.eu/instances/disease/alzheimersDiseaseModel",
+  "@id": "https://openminds.ebrains.eu/instances/diseaseModel/alzheimersDiseaseModel",
   "@type": "https://openminds.ebrains.eu/controlledTerms/DiseaseModel",
   "definition": "An animal or cell displaying all or some of the pathological processes that are observed in the actual human or animal Alzheimer's disease.",
   "description": "An animal or cell type model for Alzheimer\u2019s disease display all or some pathological processes that are observed in the actual disease in humans or animals, such as the formation of neurofibrillary tangles or amyloid-beta plaques.",

--- a/instances/diseaseModel/autismSpectrumDisorderModel
+++ b/instances/diseaseModel/autismSpectrumDisorderModel
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.ebrains.eu/vocab/"
   },
-  "@id": "https://openminds.ebrains.eu/instances/disease/autismSpectrumDisorderModel",
+  "@id": "https://openminds.ebrains.eu/instances/diseaseModel/autismSpectrumDisorderModel",
   "@type": "https://openminds.ebrains.eu/controlledTerms/DiseaseModel",
   "definition": "An animal or cell displaying all or some of the pathological processes that are observed in the actual human or animal autism sprectrum disorder.",
   "description": null,

--- a/instances/diseaseModel/fragileXsyndromeModel.jsonld
+++ b/instances/diseaseModel/fragileXsyndromeModel.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.ebrains.eu/vocab/"
   },
-  "@id": "https://openminds.ebrains.eu/instances/disease/fragileXsyndromeModel",
+  "@id": "https://openminds.ebrains.eu/instances/diseaseModel/fragileXsyndromeModel",
   "@type": "https://openminds.ebrains.eu/controlledTerms/DiseaseModel",
   "definition": "An animal or cell displaying all or some of the pathological processes that are observed in the actual human or animal fragile X syndrome.",
   "description": "An animal or cell type model for fragile X syndrome display all or some pathological processes that are observed in the actual disease in humans or animals, such as the general loss of FMR1 gene function.",

--- a/instances/diseaseModel/huntingtonsDiseaseModel.jsonld
+++ b/instances/diseaseModel/huntingtonsDiseaseModel.jsonld
@@ -2,8 +2,8 @@
   "@context": {
     "@vocab": "https://openminds.ebrains.eu/vocab/"
   },
-  "@id": "https://openminds.ebrains.eu/instances/disease/huntingtonsDiseaseModel",
-  "@type": "https://openminds.ebrains.eu/controlledTerms/Disease",
+  "@id": "https://openminds.ebrains.eu/instances/diseaseModel/huntingtonsDiseaseModel",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/DiseaseModel",
   "definition": "An animal or cell displaying all or some of the pathological processes that are observed in the actual human or animal Huntington's disease.",
   "description": null,
   "interlexIdentifier": null,

--- a/instances/diseaseModel/parkinsonsDiseaseModel.jsonld
+++ b/instances/diseaseModel/parkinsonsDiseaseModel.jsonld
@@ -2,8 +2,8 @@
   "@context": {
     "@vocab": "https://openminds.ebrains.eu/vocab/"
   },
-  "@id": "https://openminds.ebrains.eu/instances/disease/parkinsonsDiseaseModel",
-  "@type": "https://openminds.ebrains.eu/controlledTerms/Disease",
+  "@id": "https://openminds.ebrains.eu/instances/diseaseModel/parkinsonsDiseaseModel",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/DiseaseModel",
   "definition": "An animal or cell displaying all or some of the pathological processes that are observed in the actual human or animal Parkinson's disease.",
   "description": null,
   "interlexIdentifier": null,

--- a/instances/diseaseModel/williamsBeurenSyndromeModel.jsonld
+++ b/instances/diseaseModel/williamsBeurenSyndromeModel.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.ebrains.eu/vocab/"
   },
-  "@id": "https://openminds.ebrains.eu/instances/disease/williamsBeurenSyndromeModel",
+  "@id": "https://openminds.ebrains.eu/instances/diseaseModel/williamsBeurenSyndromeModel",
   "@type": "https://openminds.ebrains.eu/controlledTerms/DiseaseModel",
   "definition": "An animal or cell displaying all or some of the pathological processes that are observed in the actual human or animal Williams-Beuren syndrome.",
   "description": null,


### PR DESCRIPTION
Some `@type` and `@id` were wrong because of copy-pasting from disease to diseaseModel.