### PR TITLE
Adding AnnotationType (schema + instances)

### DIFF
--- a/instances/annotationType/deterministicAnnotation.jsonld
+++ b/instances/annotationType/deterministicAnnotation.jsonld
@@ -1,0 +1,14 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/annotationType/deterministicAnnotation",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/AnnotationType",
+  "definition": "A 'deterministic annotation' provides an exact assignment of an entity or a list of entities to a defined annotation. The assingment itself can be based on a deterministic or maximum probability assumption.",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "deterministic annotation",
+  "preferredOntologyIdentifier": null,
+  "synonym": null
+}

--- a/instances/annotationType/probabalisticAnnotation.jsonld
+++ b/instances/annotationType/probabalisticAnnotation.jsonld
@@ -1,0 +1,14 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/annotationType/probabalisticAnnotation",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/AnnotationType",
+  "definition": null,
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "probabalistic annotation",
+  "preferredOntologyIdentifier": "https://schema.org/ActiveActionStatus",
+  "synonym": null
+}

--- a/instances/annotationType/probabalisticAnnotation.jsonld
+++ b/instances/annotationType/probabalisticAnnotation.jsonld
@@ -4,11 +4,11 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/annotationType/probabalisticAnnotation",
   "@type": "https://openminds.ebrains.eu/controlledTerms/AnnotationType",
-  "definition": null,
+  "definition": "A 'probabalistic annotation' provides the probability or probabilites to which an entity or a list of entities belong(s) to a defined annotation.",
   "description": null,
   "interlexIdentifier": null,
   "knowledgeSpaceLink": null,
   "name": "probabalistic annotation",
-  "preferredOntologyIdentifier": "https://schema.org/ActiveActionStatus",
+  "preferredOntologyIdentifier": null,
   "synonym": null
 }

--- a/instances/terminology/annotationType.jsonld
+++ b/instances/terminology/annotationType.jsonld
@@ -4,7 +4,7 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/terminology/annotationType",
   "@type": "https://openminds.ebrains.eu/controlledTerms/Terminology",
-  "definition": null,
+  "definition": "General classification of how data were annotated.",
   "description": null,
   "interlexIdentifier": null,
   "knowledgeSpaceLink": null,

--- a/instances/terminology/annotationType.jsonld
+++ b/instances/terminology/annotationType.jsonld
@@ -1,0 +1,14 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/terminology/annotationType",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/Terminology",
+  "definition": null,
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "annotation type",
+  "preferredOntologyIdentifier": null,
+  "synonym": null
+}

--- a/schemas/annotationType.schema.tpl.json
+++ b/schemas/annotationType.schema.tpl.json
@@ -1,0 +1,4 @@
+{
+  "_type": "https://openminds.ebrains.eu/controlledTerms/AnnotationType",
+  "_extends": "controlledTerm.schema.tpl.json"
+}


### PR DESCRIPTION
AnnotationType was added to SANDS AtlasAnnotation and CustomAnnotation to differentiate between multiple annotations that define a ParcellationEntityVersion.

Related PR: https://github.com/HumanBrainProject/openMINDS_SANDS/pull/176