### PR TITLE
Corrected name and ontology link

### DIFF
--- a/instances/cellType/glialCell.jsonld
+++ b/instances/cellType/glialCell.jsonld
@@ -2,13 +2,13 @@
   "@context": {
     "@vocab": "https://openminds.ebrains.eu/vocab/"
   },
-  "@id": "https://openminds.ebrains.eu/instances/cellType/astrocyte",
+  "@id": "https://openminds.ebrains.eu/instances/cellType/glialCell",
   "@type": "https://openminds.ebrains.eu/controlledTerms/CellType",
   "definition": "A 'glial cell' is a non-neuronal cell of the nervous system. Glial cells provide physical support, respond to injury, regulate the ionic and chemical composition of the extracellular milieu, guide neuronal migration during development, and exchange metabolites with neurons.",
   "description": null,
-  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0100947",
+  "interlexIdentifier": "http://uri.interlex.org/base/ilx_0104634",
   "knowledgeSpaceLink": null,
-  "name": "astrocyte",
+  "name": "glial cell",
   "preferredOntologyIdentifier": null,
   "synonym": [
     "neuroglial cell"


### PR DESCRIPTION
For some reason this was linked to astrocyte. All information should now be correct.