### PR TITLE
Add instance for FTP repositories

### DIFF
--- a/instances/fileRepositoryType/ftp.jsonld
+++ b/instances/fileRepositoryType/ftp.jsonld
@@ -4,7 +4,7 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/fileRepositoryType/ftp",
   "@type": "https://openminds.ebrains.eu/controlledTerms/FileRepositoryType",
-  "definition": "FTP, the file transfer protocol, is a standard internet communication protocol which allows the transfer of files between clients and a server.",
+  "definition": "A 'FTP repository' is located on a server that uses the file transfer protocol (FTP), a standard internet communication protocol which allows the transfer of files between clients and a server.",
   "description": null,
   "interlexIdentifier": null,
   "knowledgeSpaceLink": null,

--- a/instances/fileRepositoryType/ftp.jsonld
+++ b/instances/fileRepositoryType/ftp.jsonld
@@ -10,5 +10,7 @@
   "knowledgeSpaceLink": null,
   "name": "FTP repository",
   "preferredOntologyIdentifier": null,
-  "synonym": null
+  "synonym": [
+    "file transfer protocol repository"
+  ]
 }

--- a/instances/fileRepositoryType/ftp.jsonld
+++ b/instances/fileRepositoryType/ftp.jsonld
@@ -4,7 +4,7 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/fileRepositoryType/ftp",
   "@type": "https://openminds.ebrains.eu/controlledTerms/FileRepositoryType",
-  "definition": "TODO",
+  "definition": "FTP, the file transfer protocol, is a standard internet communication protocol which allows the transfer of files between clients and a server.",
   "description": null,
   "interlexIdentifier": null,
   "knowledgeSpaceLink": null,

--- a/instances/fileRepositoryType/ftp.jsonld
+++ b/instances/fileRepositoryType/ftp.jsonld
@@ -1,0 +1,14 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "TODO",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/FileRepositoryType",
+  "definition": "TODO",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "TODO",
+  "preferredOntologyIdentifier": null,
+  "synonym": null
+}

--- a/instances/fileRepositoryType/ftp.jsonld
+++ b/instances/fileRepositoryType/ftp.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.ebrains.eu/vocab/"
   },
-  "@id": "TODO",
+  "@id": "https://openminds.ebrains.eu/instances/fileRepositoryType/ftp",
   "@type": "https://openminds.ebrains.eu/controlledTerms/FileRepositoryType",
   "definition": "TODO",
   "description": null,

--- a/instances/fileRepositoryType/ftp.jsonld
+++ b/instances/fileRepositoryType/ftp.jsonld
@@ -8,7 +8,7 @@
   "description": null,
   "interlexIdentifier": null,
   "knowledgeSpaceLink": null,
-  "name": "TODO",
+  "name": "FTP repository",
   "preferredOntologyIdentifier": null,
   "synonym": null
 }


### PR DESCRIPTION
To support the Big Brain file repository it is necessary to support FTP data repositories as FileRepositoryType.