### PR TITLE
Pittsburgh Compound B (PiB)

### DIFF
--- a/instances/molecularEntity/pittsburghCompoundB.jsonld
+++ b/instances/molecularEntity/pittsburghCompoundB.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/molecularEntity/pittsburghCompoundB",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/MolecularEntity",
+  "definition": "Pittsburgh compound B (PiB) is a radioactive analog of thioflavin T, which can be used in positron emission tomography scans to image beta-amyloid plaques in neuronal tissue. Due to this property, Pittsburgh compound B may be used in investigational studies of Alzheimer's disease.",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "Pittsburgh Compound B (PiB)",
+  "preferredOntologyIdentifier": null,
+  "synonym": [
+    "Pittsburgh Compound B",
+    "PiB",
+    "benzothiazole-1",
+    "BTA-1",
+    "2-{4-[(11C)Methylamino]phenyl}-1,3-benzothiazol-6-ol"
+  ]
+}


### PR DESCRIPTION
Hello,

I suggest to add Pittsburgh Compound B (PiB), a PET tracer that binds to beta-amyloid plaques, to controlledTerms/molecularEntity. Haven't found it on InterLex or in the KnowledgeSpace, is that a problem? Not sure what to add under preferredOntologyIdentifier either. What do you think?

Best,
Eszter